### PR TITLE
Issue #9, #10 Vehicle Info Journey

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true,
-  "typescript.preferences.importModuleSpecifier": "project-relative",
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "workbench.settings.editor": "json"
 }

--- a/src/app/components/file-upload/components/index.ts
+++ b/src/app/components/file-upload/components/index.ts
@@ -1,0 +1,1 @@
+export * from './photo-guidelines/photo-guidelines.component';

--- a/src/app/components/file-upload/file-upload.module.ts
+++ b/src/app/components/file-upload/file-upload.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { CardModule } from 'primeng/card';
 import { FileUploadModule as PrimeFileUploadModule } from 'primeng/fileupload';
 import { SecureMessageComponent } from '../secure-message/secure-message.component';
-import { PhotoGuidelinesComponent } from './components/photo-guidelines/photo-guidelines.component';
+import { PhotoGuidelinesComponent } from './components';
 import { FileUploadComponent } from './file-upload.component';
 
 @NgModule({

--- a/src/app/components/icons/icons.component.ts
+++ b/src/app/components/icons/icons.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import {
   IconDefinition,
   faBars,
@@ -45,7 +46,8 @@ export type AvailableIcons =
   | 'question'
   | 'x'
   | 'chevronLeft'
-  | 'chevronRight';
+  | 'chevronRight'
+  | 'checkCircleOutline';
 
 @Component({
   selector: 'app-icons',
@@ -80,6 +82,7 @@ export class IconsComponent implements OnInit {
     x: faX,
     chevronLeft: faChevronLeft,
     chevronRight: faChevronRight,
+    checkCircleOutline: faCheckCircle,
   };
   constructor() {}
 

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -1,3 +1,6 @@
+export * from './file-upload/file-upload.module';
 export * from './help-panel/help-panel.component';
 export * from './icons/icons.component';
+export * from './loading-spinner/loading-spinner.component';
 export * from './masterpage';
+export * from './secure-message/secure-message.component';

--- a/src/app/routes/home/components/index.ts
+++ b/src/app/routes/home/components/index.ts
@@ -1,0 +1,1 @@
+export * from './loan-thumb/loan-thumb.component';

--- a/src/app/routes/home/home.module.ts
+++ b/src/app/routes/home/home.module.ts
@@ -8,7 +8,7 @@ import { routing } from './home.routes';
 // Components
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
-import { LoanThumbComponent } from './components/loan-thumb/loan-thumb.component';
+import { LoanThumbComponent } from './components';
 import { HomeComponent } from './home.component';
 
 @NgModule({

--- a/src/app/routes/loan/components/index.ts
+++ b/src/app/routes/loan/components/index.ts
@@ -1,0 +1,2 @@
+export * from './loan-back-nav/loan-back-nav.component';
+export * from './verification-task/verification-task.component';

--- a/src/app/routes/loan/components/verification-task/verification-task.component.html
+++ b/src/app/routes/loan/components/verification-task/verification-task.component.html
@@ -1,11 +1,9 @@
 <!-- TODO: Need to take into account the various states and the associated interface changes -->
 
 @if (isActionable()) {
-  <div class="actionable">
+  <div class="actionable" [routerLink]="route()">
     <span>Verify {{ verificationTask().type | verificationType }}</span>
-    <a [routerLink]="route()">
-      <app-icons icon="chevronRight" />
-    </a>
+    <app-icons icon="chevronRight" />
   </div>
 } @else {
   <div class="verified">

--- a/src/app/routes/loan/components/verification-task/verification-task.component.html
+++ b/src/app/routes/loan/components/verification-task/verification-task.component.html
@@ -1,8 +1,18 @@
 <!-- TODO: Need to take into account the various states and the associated interface changes -->
-<span>Verify {{ verificationTask().type | verificationType }}</span>
 
 @if (isActionable()) {
-  <a [routerLink]="route()">
-    <app-icons icon="chevronRight" />
-  </a>
+  <div class="actionable">
+    <span>Verify {{ verificationTask().type | verificationType }}</span>
+    <a [routerLink]="route()">
+      <app-icons icon="chevronRight" />
+    </a>
+  </div>
+} @else {
+  <div class="verified">
+    <app-icons icon="checkCircleOutline" />
+    <span class="label">
+      <span>Verify {{ verificationTask().type | verificationType }}</span>
+      <span class="status">Verified</span>
+    </span>
+  </div>
 }

--- a/src/app/routes/loan/components/verification-task/verification-task.component.scss
+++ b/src/app/routes/loan/components/verification-task/verification-task.component.scss
@@ -17,6 +17,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  cursor: pointer;
 
   app-icons {
     color: var(--Primary-OMF-Sky);

--- a/src/app/routes/loan/components/verification-task/verification-task.component.scss
+++ b/src/app/routes/loan/components/verification-task/verification-task.component.scss
@@ -1,6 +1,5 @@
 :host {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   background-color: var(--Primary-OMF-White);
   height: 70px;
@@ -13,7 +12,35 @@
   font-weight: 400;
 }
 
-app-icons {
-  color: var(--Primary-OMF-Sky);
-  font-size: 20px;
+.actionable {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+
+  app-icons {
+    color: var(--Primary-OMF-Sky);
+    font-size: 20px;
+  }
+}
+
+.verified {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  app-icons {
+    font-size: 22px;
+    margin-right: 15px;
+  }
+}
+.label {
+  display: flex;
+  flex-direction: column;
+}
+.status {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  color: var(--Font-Gray);
 }

--- a/src/app/routes/loan/loan.component.html
+++ b/src/app/routes/loan/loan.component.html
@@ -5,10 +5,7 @@
 
     @switch (routeApi.loanDetailsLoadingState$ | async) {
       @case (LoadingState.Loading) {
-        <p-card>
-          <p-progressSpinner></p-progressSpinner>
-          <p>Loading</p>
-        </p-card>
+        <app-loading-spinner />
       }
       @case (LoadingState.Success) {
         <h2>You have {{ tasksToComplete$ | async }} tasks to complete</h2>

--- a/src/app/routes/loan/loan.module.ts
+++ b/src/app/routes/loan/loan.module.ts
@@ -4,8 +4,8 @@ import { LoanComponent } from '../loan/loan.component';
 // Routing
 import { SharedModule } from '$shared';
 import { CardModule } from 'primeng/card';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { HelpPanelComponent, IconsComponent, MasterPageModule } from '../../components';
+import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
 import { LoanBackNavComponent } from './components/loan-back-nav/loan-back-nav.component';
 import { VerificationTaskComponent } from './components/verification-task/verification-task.component';
 import { routing } from './loan.routes';
@@ -14,7 +14,7 @@ import { RouteApiService } from './shared/store/api/route-api.service';
 
 @NgModule({
   declarations: [LoanComponent, LoanBackNavComponent, VerificationTaskComponent, VerificationTypePipe],
-  imports: [CommonModule, SharedModule, routing, MasterPageModule, HelpPanelComponent, CardModule, ProgressSpinnerModule, IconsComponent],
+  imports: [CommonModule, SharedModule, routing, MasterPageModule, HelpPanelComponent, CardModule, IconsComponent, LoadingSpinnerComponent],
   providers: [RouteApiService],
 })
 export class LoanModule {}

--- a/src/app/routes/loan/loan.module.ts
+++ b/src/app/routes/loan/loan.module.ts
@@ -2,12 +2,10 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { LoanComponent } from '../loan/loan.component';
 // Routing
+import { HelpPanelComponent, IconsComponent, LoadingSpinnerComponent, MasterPageModule } from '$components';
 import { SharedModule } from '$shared';
 import { CardModule } from 'primeng/card';
-import { HelpPanelComponent, IconsComponent, MasterPageModule } from '../../components';
-import { LoadingSpinnerComponent } from '../../components/loading-spinner/loading-spinner.component';
-import { LoanBackNavComponent } from './components/loan-back-nav/loan-back-nav.component';
-import { VerificationTaskComponent } from './components/verification-task/verification-task.component';
+import { LoanBackNavComponent, VerificationTaskComponent } from './components';
 import { routing } from './loan.routes';
 import { VerificationTypePipe } from './pipes/verification-type.pipe';
 import { RouteApiService } from './shared/store/api/route-api.service';

--- a/src/app/routes/loan/loan.routes.ts
+++ b/src/app/routes/loan/loan.routes.ts
@@ -6,6 +6,11 @@ import { LoanModule } from './loan.module';
 
 const routes: Routes = [
   {
+    path: ':loanId/vehicle',
+    // canActivate: [AuthGuard],
+    loadChildren: () => import('./routes/vehicle/vehicle.module').then(m => m.VehicleModule),
+  },
+  {
     path: ':loanId/income',
     // canActivate: [AuthGuard],
     loadChildren: () => import('./routes/income/income.module').then(m => m.IncomeModule),

--- a/src/app/routes/loan/routes/income/components/index.ts
+++ b/src/app/routes/loan/routes/income/components/index.ts
@@ -1,0 +1,2 @@
+export * from './irs-verify-action/irs-verify-action.component';
+export * from './plaid-verify-action/plaid-verify-action.component';

--- a/src/app/routes/loan/routes/income/income.module.ts
+++ b/src/app/routes/loan/routes/income/income.module.ts
@@ -1,11 +1,8 @@
+import { HelpPanelComponent, LoadingSpinnerComponent, MasterPageModule } from '$components';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { CardModule } from 'primeng/card';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { HelpPanelComponent, MasterPageModule } from '../../../../components';
-import { LoadingSpinnerComponent } from '../../../../components/loading-spinner/loading-spinner.component';
-import { IrsVerifyActionComponent } from './components/irs-verify-action/irs-verify-action.component';
-import { PlaidVerifyActionComponent } from './components/plaid-verify-action/plaid-verify-action.component';
+import { IrsVerifyActionComponent, PlaidVerifyActionComponent } from './components';
 import { IncomeComponent } from './income.component';
 import { routing } from './income.routes';
 import { RouteApiService } from './shared/store/api/route-api.service';
@@ -18,7 +15,6 @@ import { RouteApiService } from './shared/store/api/route-api.service';
     MasterPageModule,
     HelpPanelComponent,
     CardModule,
-    ProgressSpinnerModule,
     PlaidVerifyActionComponent,
     IrsVerifyActionComponent,
     LoadingSpinnerComponent,

--- a/src/app/routes/loan/routes/income/routes/income-manual/income-manual.component.html
+++ b/src/app/routes/loan/routes/income/routes/income-manual/income-manual.component.html
@@ -10,12 +10,16 @@
       <p>Please select the document you want to provide to verify your income.</p>
 
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
-        <p-dropdown
-          formControlName="dropdown"
-          [loading]="(manualIncomeRouteApi.manualIncomeVerificationMethodsLoadingState$ | async) === LoadingState.Loading"
-          [options]="(manualIncomeRouteApi.manualIncomeVerificationMethods$ | async)!"
-        ></p-dropdown>
-        <p-button type="submit" [rounded]="true" [disabled]="form.invalid" label="Continue"></p-button>
+        <div>
+          <p-dropdown
+            formControlName="dropdown"
+            [loading]="(manualIncomeRouteApi.manualIncomeVerificationMethodsLoadingState$ | async) === LoadingState.Loading"
+            [options]="(manualIncomeRouteApi.manualIncomeVerificationMethods$ | async)!"
+          />
+        </div>
+        <div>
+          <p-button type="submit" [rounded]="true" [disabled]="form.invalid" label="Continue"></p-button>
+        </div>
       </form>
 
       <app-secure-message />

--- a/src/app/routes/loan/routes/income/routes/income-manual/income-manual.component.ts
+++ b/src/app/routes/loan/routes/income/routes/income-manual/income-manual.component.ts
@@ -18,7 +18,7 @@ export class IncomeManualComponent implements OnInit, OnDestroy {
   protected readonly IncomeVerificationMethod = Models.IncomeVerificationMethod;
 
   protected form = this.fb.group({
-    dropdown: new FormControl<Models.ManualIncomeVerificationMethod | undefined>(undefined, Validators.required),
+    dropdown: new FormControl<Models.GenericVerificationMethod | undefined>(undefined, Validators.required),
   });
 
   protected fileUploader = signal(false);
@@ -52,7 +52,7 @@ export class IncomeManualComponent implements OnInit, OnDestroy {
       this.manualIncomeRouteApi.manualIncomeVerificationMethods$
         .pipe(
           filter(options => !!options && !!options.length),
-          map(options => (options as Models.ManualIncomeVerificationMethod[])[0]),
+          map(options => (options as Models.GenericVerificationMethod[])[0]),
         )
         .subscribe(option => this.form.controls['dropdown'].setValue(option)),
     );

--- a/src/app/routes/loan/routes/income/routes/income-manual/income-manual.module.ts
+++ b/src/app/routes/loan/routes/income/routes/income-manual/income-manual.module.ts
@@ -1,16 +1,11 @@
+import { FileUploadModule, HelpPanelComponent, LoadingSpinnerComponent, MasterPageModule, SecureMessageComponent } from '$components';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { DropdownModule } from 'primeng/dropdown';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { HelpPanelComponent, MasterPageModule } from '../../../../../../components';
-import { FileUploadModule } from '../../../../../../components/file-upload/file-upload.module';
-import { LoadingSpinnerComponent } from '../../../../../../components/loading-spinner/loading-spinner.component';
-import { SecureMessageComponent } from '../../../../../../components/secure-message/secure-message.component';
-import { IrsVerifyActionComponent } from '../../components/irs-verify-action/irs-verify-action.component';
-import { PlaidVerifyActionComponent } from '../../components/plaid-verify-action/plaid-verify-action.component';
+import { IrsVerifyActionComponent, PlaidVerifyActionComponent } from '../../components';
 import { IncomeManualComponent } from './income-manual.component';
 import { routing } from './income-manual.routes';
 import { RouteApiService } from './shared/store/api/route-api.service';
@@ -27,7 +22,6 @@ import { RouteApiService } from './shared/store/api/route-api.service';
     ButtonModule,
     CardModule,
     DropdownModule,
-    ProgressSpinnerModule,
     PlaidVerifyActionComponent,
     IrsVerifyActionComponent,
     SecureMessageComponent,

--- a/src/app/routes/loan/routes/income/routes/income-manual/shared/store/api/route-api.service.ts
+++ b/src/app/routes/loan/routes/income/routes/income-manual/shared/store/api/route-api.service.ts
@@ -11,7 +11,7 @@ import LOANS from '../../../../../../../../../../assets/mock-data/loans';
 @Injectable()
 export class RouteApiService {
   manualIncomeVerificationMethodsLoadingState$ = new BehaviorSubject<Models.LoadingState>(Models.LoadingState.Unloaded);
-  manualIncomeVerificationMethods$ = new BehaviorSubject<Models.ManualIncomeVerificationMethod[] | undefined>(undefined);
+  manualIncomeVerificationMethods$ = new BehaviorSubject<Models.GenericVerificationMethod[] | undefined>(undefined);
   manualIncomeVerificationMethodsErrorMessage$ = new BehaviorSubject<string>('');
 
   listManualIncomeVerificationMethods(loanId: number) {

--- a/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.html
+++ b/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.html
@@ -1,0 +1,12 @@
+<p-card>
+  <h2>Please gather the following:</h2>
+
+  <ul>
+    <li>Vehicle Registration</li>
+    <li>Insurance Card</li>
+    <li>Photo of <span class="tooltip" pTooltip="Vehicle Identification Number">VIN</span></li>
+    <li>Photo of Odometer</li>
+    <li>2 Photos of Vehicle</li>
+    <li><span class="tooltip" pTooltip="Such as a vehicle title">Proof of Ownership</span> (if applicable)</li>
+  </ul>
+</p-card>

--- a/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.scss
+++ b/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.scss
@@ -1,0 +1,43 @@
+:host {
+  display: block;
+  text-align: center;
+  margin-bottom: 30px;
+
+  ::ng-deep .p-card-content {
+    padding: 0;
+  }
+}
+
+h2 {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 25px;
+  margin-bottom: 20px;
+}
+
+ul {
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 28px;
+  margin: 0;
+}
+
+li {
+  list-style-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2215%22%20height%3D%2214%22%20viewBox%3D%220%200%2015%2014%22%20fill%3D%22none%22%3E%3Cpath%20d%3D%22M1%207.85714L5.28571%2013L13.8571%201%22%20stroke%3D%22%232659D9%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E');
+  text-align: left;
+  text-indent: 5px;
+
+  &::marker {
+    color: var(--Primary-OMF-Sky);
+  }
+}
+
+p-card {
+  display: block;
+  text-align: center;
+
+  ::ng-deep .p-card {
+    box-shadow: none;
+    border: 1px solid var(--Primary-OMF-Sky-Light, #e0ebf5);
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.ts
+++ b/src/app/routes/loan/routes/vehicle/components/documents-checklist/documents-checklist.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-documents-checklist',
+  templateUrl: './documents-checklist.component.html',
+  styleUrls: ['./documents-checklist.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocumentsChecklistComponent {}

--- a/src/app/routes/loan/routes/vehicle/components/index.ts
+++ b/src/app/routes/loan/routes/vehicle/components/index.ts
@@ -1,0 +1,1 @@
+export * from './documents-checklist/documents-checklist.component';

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/shared/store/api/route-api.service.ts
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/shared/store/api/route-api.service.ts
@@ -1,0 +1,40 @@
+import { Models } from '$shared';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import LOANS from '../../../../../../../../../../assets/mock-data/loans';
+// import { environment } from '$env'; // Base api url
+
+/**
+ * Route specific api stores
+ * By default they are not injected in root since they are only needed by this route
+ */
+@Injectable()
+export class RouteApiService {
+  manualVehicleVerificationMethodsLoadingState$ = new BehaviorSubject<Models.LoadingState>(Models.LoadingState.Unloaded);
+  manualVehicleVerificationMethods$ = new BehaviorSubject<Models.GenericVerificationMethod[] | undefined>(undefined);
+  manualVehicleVerificationMethodsErrorMessage$ = new BehaviorSubject<string>('');
+
+  listManualVehicleVerificationMethods(loanId: number) {
+    this.manualVehicleVerificationMethodsLoadingState$.next(Models.LoadingState.Loading);
+    this.manualVehicleVerificationMethods$.next([]);
+    this.manualVehicleVerificationMethodsErrorMessage$.next('');
+
+    setTimeout(() => {
+      const loan = LOANS.find(loan => loan.id === loanId);
+      if (loan) {
+        this.manualVehicleVerificationMethods$.next([
+          { id: 0, stub: 'registration', label: 'Vehicle Registration' },
+          { id: 1, stub: 'insurance', label: 'Insurance Card' },
+          { id: 2, stub: 'vin', label: 'Photo of VIN' },
+          { id: 3, stub: 'odometer', label: 'Photo of Odometer' },
+          { id: 3, stub: 'vehicle', label: '2 Photos of Vehicle' },
+          { id: 3, stub: 'ownership', label: 'Proof of Ownership' },
+        ]);
+        this.manualVehicleVerificationMethodsLoadingState$.next(Models.LoadingState.Success);
+      } else {
+        this.manualVehicleVerificationMethodsErrorMessage$.next('Loan not found');
+        this.manualVehicleVerificationMethodsLoadingState$.next(Models.LoadingState.Error);
+      }
+    }, 750);
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.html
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.html
@@ -1,0 +1,38 @@
+<app-masterpage>
+  <section class="forground">
+    @if (fileUploader()) {
+      <app-file-upload [label]="verificationMethod?.label || 'Verify Vehicle Information'" [backFunction]="fileUploadBack">
+        Take a photo or upload a file
+      </app-file-upload>
+    } @else {
+      <nav><a routerLink="../">‹ Go Back</a></nav>
+      <h1>Verify Vehicle Information</h1>
+      <p>We need a few documents to verify your vehicle information.</p>
+
+      @switch (manualVehicleRouteApi.manualVehicleVerificationMethodsLoadingState$ | async) {
+        @case (LoadingState.Loading) {
+          <app-loading-spinner />
+        }
+        @case (LoadingState.Success) {
+          <nav>
+            @for (verificationTask of manualVehicleRouteApi.manualVehicleVerificationMethods$ | async; track verificationTask.id) {
+              <p-card (click)="navigateToVerification(verificationTask)" class="verificationTask">
+                <span>{{ verificationTask.label }}</span>
+                <app-icons icon="chevronRight" />
+              </p-card>
+            }
+          </nav>
+        }
+        @case (LoadingState.Error) {
+          <p-card>
+            <h2>There was an error loading the vehicle verification list.</h2>
+            <p>Details: {{ manualVehicleRouteApi.manualVehicleVerificationMethodsErrorMessage$ | async }}</p>
+          </p-card>
+        }
+      }
+    }
+  </section>
+  <section>
+    <app-help-panel />
+  </section>
+</app-masterpage>

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.scss
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.scss
@@ -1,0 +1,97 @@
+:host {
+  display: block;
+  width: 100%;
+
+  ::ng-deep {
+    .p-dropdown {
+      width: 100%;
+      max-width: 320px;
+      margin-bottom: 30px;
+    }
+
+    .p-dropdown-label {
+      font-size: 18px;
+      line-height: 25px;
+      padding: 15px;
+    }
+
+    .p-dropdown-items {
+      margin: 0;
+      background-color: var(--body-background-color);
+    }
+
+    .p-dropdown-item {
+      padding: 15px;
+      font-size: 18px;
+      line-height: 25px;
+    }
+
+    .p-button {
+      font-size: 20px;
+      font-weight: 300;
+      line-height: 24px;
+      padding: 12px 16px;
+      width: 100%;
+      max-width: 320px;
+    }
+  }
+}
+
+section {
+  padding: var(--body-padding);
+
+  &.forground {
+    background-color: var(--Primary-OMF-White);
+  }
+}
+
+nav {
+  font-size: 15px;
+  line-height: 24px;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: 32px;
+  font-weight: 300;
+  line-height: 1;
+  margin-bottom: 15px;
+}
+
+p {
+  font-size: 18px;
+  line-height: 25px;
+  font-weight: 400;
+}
+
+form {
+  margin-bottom: 30px;
+}
+
+.verificationTask {
+  display: block;
+  cursor: pointer;
+  margin-bottom: 10px;
+
+  app-icons {
+    color: var(--Primary-OMF-Sky);
+    font-size: 20px;
+  }
+
+  ::ng-deep {
+    .p-card {
+      box-shadow: none;
+      border: 1px solid var(--Primary-OMF-Sky-Light, #e0ebf5);
+      width: 100%;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 28px;
+    }
+    .p-card-content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    }
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.ts
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.component.ts
@@ -1,0 +1,53 @@
+import { Models } from '$shared';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, signal } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription, map } from 'rxjs';
+import { RouteApiService as VehicleRouteApiService } from '../../shared/store/api/route-api.service';
+import { RouteApiService as ManualVehicleRouteApiService } from './shared/store/api/route-api.service';
+
+@Component({
+  selector: 'app-vehicle-manual',
+  templateUrl: './vehicle-manual.component.html',
+  styleUrls: ['./vehicle-manual.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VehicleManualComponent implements OnInit, OnDestroy {
+  private subscriptions = new Subscription();
+  protected readonly LoadingState = Models.LoadingState;
+  protected readonly IncomeVerificationMethod = Models.IncomeVerificationMethod;
+
+  protected verificationMethod: Models.GenericVerificationMethod | null = null;
+
+  protected fileUploader = signal(false);
+
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    protected vehicleRouteApi: VehicleRouteApiService,
+    protected manualVehicleRouteApi: ManualVehicleRouteApiService,
+  ) {}
+
+  protected fileUploadBack = () => {
+    this.fileUploader.set(false);
+    this.verificationMethod = null;
+  };
+
+  navigateToVerification(method: Models.GenericVerificationMethod) {
+    this.verificationMethod = method;
+    this.fileUploader.set(true);
+  }
+
+  ngOnInit() {
+    this.subscriptions.add(
+      this.route.params.pipe(map(params => parseInt(params['loanId'], 10))).subscribe(loanId => {
+        this.vehicleRouteApi.listVehicleVerificationMethods(loanId);
+        this.manualVehicleRouteApi.listManualVehicleVerificationMethods(loanId);
+      }),
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.module.ts
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.module.ts
@@ -1,14 +1,10 @@
+import { FileUploadModule, HelpPanelComponent, IconsComponent, LoadingSpinnerComponent, MasterPageModule, SecureMessageComponent } from '$components';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { DropdownModule } from 'primeng/dropdown';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { HelpPanelComponent, IconsComponent, MasterPageModule } from '../../../../../../components';
-import { FileUploadModule } from '../../../../../../components/file-upload/file-upload.module';
-import { LoadingSpinnerComponent } from '../../../../../../components/loading-spinner/loading-spinner.component';
-import { SecureMessageComponent } from '../../../../../../components/secure-message/secure-message.component';
 import { RouteApiService } from './shared/store/api/route-api.service';
 import { VehicleManualComponent } from './vehicle-manual.component';
 import { routing } from './vehicle-manual.routes';
@@ -25,7 +21,6 @@ import { routing } from './vehicle-manual.routes';
     ButtonModule,
     CardModule,
     DropdownModule,
-    ProgressSpinnerModule,
     SecureMessageComponent,
     LoadingSpinnerComponent,
     FileUploadModule,

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.module.ts
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.module.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { DropdownModule } from 'primeng/dropdown';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { HelpPanelComponent, IconsComponent, MasterPageModule } from '../../../../../../components';
+import { FileUploadModule } from '../../../../../../components/file-upload/file-upload.module';
+import { LoadingSpinnerComponent } from '../../../../../../components/loading-spinner/loading-spinner.component';
+import { SecureMessageComponent } from '../../../../../../components/secure-message/secure-message.component';
+import { RouteApiService } from './shared/store/api/route-api.service';
+import { VehicleManualComponent } from './vehicle-manual.component';
+import { routing } from './vehicle-manual.routes';
+
+@NgModule({
+  declarations: [VehicleManualComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    routing,
+    MasterPageModule,
+    HelpPanelComponent,
+    ButtonModule,
+    CardModule,
+    DropdownModule,
+    ProgressSpinnerModule,
+    SecureMessageComponent,
+    LoadingSpinnerComponent,
+    FileUploadModule,
+    IconsComponent,
+  ],
+  providers: [RouteApiService],
+})
+export class VehicleManualModule {}

--- a/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.routes.ts
+++ b/src/app/routes/loan/routes/vehicle/routes/vehicle-manual/vehicle-manual.routes.ts
@@ -1,0 +1,16 @@
+import { titleAppendSlug } from '$shared';
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VehicleManualComponent } from './vehicle-manual.component';
+import { VehicleManualModule } from './vehicle-manual.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    // canActivate: [AuthGuard],
+    component: VehicleManualComponent,
+    title: titleAppendSlug('Verify Income: Manual'),
+  },
+];
+
+export const routing: ModuleWithProviders<VehicleManualModule> = RouterModule.forChild(routes);

--- a/src/app/routes/loan/routes/vehicle/shared/store/api/route-api.service.ts
+++ b/src/app/routes/loan/routes/vehicle/shared/store/api/route-api.service.ts
@@ -1,0 +1,33 @@
+import { Models } from '$shared';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import LOANS from '../../../../../../../../assets/mock-data/loans';
+// import { environment } from '$env'; // Base api url
+
+/**
+ * Route specific api stores
+ * By default they are not injected in root since they are only needed by this route
+ */
+@Injectable()
+export class RouteApiService {
+  incomeVerificationMethodsLoadingState$ = new BehaviorSubject<Models.LoadingState>(Models.LoadingState.Unloaded);
+  incomeVerificationMethods$ = new BehaviorSubject<Models.IncomeVerificationMethod[]>([]);
+  incomeVerificationMethodsErrorMessage$ = new BehaviorSubject<string>('');
+
+  listVehicleVerificationMethods(loanId: number) {
+    this.incomeVerificationMethodsLoadingState$.next(Models.LoadingState.Loading);
+    this.incomeVerificationMethods$.next([]);
+    this.incomeVerificationMethodsErrorMessage$.next('');
+
+    setTimeout(() => {
+      const loan = LOANS.find(loan => loan.id === loanId);
+      if (loan) {
+        this.incomeVerificationMethods$.next([Models.IncomeVerificationMethod.Plaid, Models.IncomeVerificationMethod.IRS]);
+        this.incomeVerificationMethodsLoadingState$.next(Models.LoadingState.Success);
+      } else {
+        this.incomeVerificationMethodsErrorMessage$.next('Loan not found');
+        this.incomeVerificationMethodsLoadingState$.next(Models.LoadingState.Error);
+      }
+    }, 500);
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/vehicle.component.html
+++ b/src/app/routes/loan/routes/vehicle/vehicle.component.html
@@ -1,0 +1,15 @@
+<app-masterpage>
+  <section class="forground">
+    <nav><a routerLink="../">‹ Go Back</a></nav>
+    <h1>Verify Vehicle Information</h1>
+    <p>We need a few documents to verify your vehicle information.</p>
+    <app-documents-checklist />
+
+    <p class="manual">
+      <p-button [rounded]="true" label="Continue" routerLink="manual" />
+    </p>
+  </section>
+  <section>
+    <app-help-panel />
+  </section>
+</app-masterpage>

--- a/src/app/routes/loan/routes/vehicle/vehicle.component.scss
+++ b/src/app/routes/loan/routes/vehicle/vehicle.component.scss
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+  width: 100%;
+
+  ::ng-deep {
+    .p-button {
+      font-size: 20px;
+      font-weight: 300;
+      line-height: 24px;
+      padding: 12px 16px;
+      width: 100%;
+      max-width: 320px;
+    }
+  }
+}
+
+section {
+  padding: var(--body-padding);
+
+  &.forground {
+    background-color: var(--Primary-OMF-White);
+  }
+}
+
+nav {
+  font-size: 15px;
+  line-height: 24px;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: 32px;
+  font-weight: 300;
+  line-height: 1;
+  margin-bottom: 15px;
+}
+
+p {
+  font-size: 18px;
+  line-height: 25px;
+  font-weight: 400;
+
+  &.manual {
+    text-align: center;
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/vehicle.component.ts
+++ b/src/app/routes/loan/routes/vehicle/vehicle.component.ts
@@ -1,0 +1,44 @@
+import { Models } from '$shared';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription, concatMap, filter, map } from 'rxjs';
+import { RouteApiService } from './shared/store/api/route-api.service';
+
+@Component({
+  selector: 'app-vehicle',
+  templateUrl: './vehicle.component.html',
+  styleUrls: ['./vehicle.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VehicleComponent implements OnInit, OnDestroy {
+  private subscriptions = new Subscription();
+  protected readonly LoadingState = Models.LoadingState;
+  protected readonly IncomeVerificationMethod = Models.IncomeVerificationMethod;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    protected routeApi: RouteApiService,
+  ) {}
+
+  ngOnInit() {
+    this.subscriptions.add(
+      this.route.params.pipe(map(params => parseInt(params['loanId'], 10))).subscribe(loanId => this.routeApi.listVehicleVerificationMethods(loanId)),
+    );
+
+    this.subscriptions.add(
+      this.routeApi.incomeVerificationMethodsLoadingState$
+        .pipe(
+          filter(state => [Models.LoadingState.Success, Models.LoadingState.Error].includes(state)),
+
+          concatMap(() => this.routeApi.incomeVerificationMethods$),
+          filter(methods => !methods.length),
+        )
+        .subscribe(() => this.router.navigate(['manual'], { relativeTo: this.route })),
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+}

--- a/src/app/routes/loan/routes/vehicle/vehicle.module.ts
+++ b/src/app/routes/loan/routes/vehicle/vehicle.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { TooltipModule } from 'primeng/tooltip';
+import { HelpPanelComponent, MasterPageModule } from '../../../../components';
+import { LoadingSpinnerComponent } from '../../../../components/loading-spinner/loading-spinner.component';
+import { DocumentsChecklistComponent } from './components/documents-checklist/documents-checklist.component';
+import { RouteApiService } from './shared/store/api/route-api.service';
+import { VehicleComponent } from './vehicle.component';
+import { routing } from './vehicle.routes';
+
+@NgModule({
+  declarations: [VehicleComponent, DocumentsChecklistComponent],
+  imports: [
+    CommonModule,
+    routing,
+    MasterPageModule,
+    HelpPanelComponent,
+    ButtonModule,
+    CardModule,
+    TooltipModule,
+    ProgressSpinnerModule,
+    LoadingSpinnerComponent,
+  ],
+  providers: [RouteApiService],
+})
+export class VehicleModule {}

--- a/src/app/routes/loan/routes/vehicle/vehicle.module.ts
+++ b/src/app/routes/loan/routes/vehicle/vehicle.module.ts
@@ -1,29 +1,17 @@
+import { HelpPanelComponent, LoadingSpinnerComponent, MasterPageModule } from '$components';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { TooltipModule } from 'primeng/tooltip';
-import { HelpPanelComponent, MasterPageModule } from '../../../../components';
-import { LoadingSpinnerComponent } from '../../../../components/loading-spinner/loading-spinner.component';
-import { DocumentsChecklistComponent } from './components/documents-checklist/documents-checklist.component';
+import { DocumentsChecklistComponent } from './components';
 import { RouteApiService } from './shared/store/api/route-api.service';
 import { VehicleComponent } from './vehicle.component';
 import { routing } from './vehicle.routes';
 
 @NgModule({
   declarations: [VehicleComponent, DocumentsChecklistComponent],
-  imports: [
-    CommonModule,
-    routing,
-    MasterPageModule,
-    HelpPanelComponent,
-    ButtonModule,
-    CardModule,
-    TooltipModule,
-    ProgressSpinnerModule,
-    LoadingSpinnerComponent,
-  ],
+  imports: [CommonModule, routing, MasterPageModule, HelpPanelComponent, ButtonModule, CardModule, TooltipModule, LoadingSpinnerComponent],
   providers: [RouteApiService],
 })
 export class VehicleModule {}

--- a/src/app/routes/loan/routes/vehicle/vehicle.routes.ts
+++ b/src/app/routes/loan/routes/vehicle/vehicle.routes.ts
@@ -1,0 +1,21 @@
+import { titleAppendSlug } from '$shared';
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { VehicleComponent } from './vehicle.component';
+import { VehicleModule } from './vehicle.module';
+
+const routes: Routes = [
+  {
+    path: 'manual',
+    // canActivate: [AuthGuard],
+    loadChildren: () => import('./routes/vehicle-manual/vehicle-manual.module').then(m => m.VehicleManualModule),
+  },
+  {
+    path: '',
+    component: VehicleComponent,
+    // canActivate: [AuthGuard],
+    title: titleAppendSlug('Verify Vehicle'),
+  },
+];
+
+export const routing: ModuleWithProviders<VehicleModule> = RouterModule.forChild(routes);

--- a/src/app/routes/loan/shared/store/api/route-api.service.ts
+++ b/src/app/routes/loan/shared/store/api/route-api.service.ts
@@ -27,9 +27,9 @@ export class RouteApiService {
           type: loan.type,
           status: loan.status,
           verifications: [
-            { type: Models.VerificationTypes.Identity, status: Models.VerificationStatus.ActionRequired },
+            { type: Models.VerificationTypes.Identity, status: Models.VerificationStatus.Verified },
             { type: Models.VerificationTypes.Income, status: Models.VerificationStatus.ActionRequired },
-            { type: Models.VerificationTypes.Vehicle, status: Models.VerificationStatus.Verified },
+            { type: Models.VerificationTypes.Vehicle, status: Models.VerificationStatus.ActionRequired },
           ],
         });
         this.loanDetailsLoadingState$.next(Models.LoadingState.Success);

--- a/src/app/shared/models/global.models.ts
+++ b/src/app/shared/models/global.models.ts
@@ -98,7 +98,7 @@ export module Models {
     IRS, // TODO: Made this up, delete this method
   }
 
-  export interface ManualIncomeVerificationMethod {
+  export interface GenericVerificationMethod {
     id: number;
     stub: string;
     label: string;

--- a/src/styles/components/_cards.scss
+++ b/src/styles/components/_cards.scss
@@ -11,4 +11,8 @@ body .p-card {
     background-color: rgba(0, 0, 0, 0.03);
     border-top: 1px solid rgba(0, 0, 0, 0.125);
   }
+
+  .p-card-content {
+    padding: 0;
+  }
 }

--- a/src/styles/components/_poptooltips.scss
+++ b/src/styles/components/_poptooltips.scss
@@ -8,8 +8,8 @@
   }
 }
 .tooltip {
-  background: #fff !important;
-  color: #000 !important;
+  color: var(--Primary-OMF-Sky);
+  text-decoration: underline;
 }
 
 @keyframes fadein {


### PR DESCRIPTION
Was going to do this in two but ended up doing these in one PR.

Issue #9 
Issue #10 

I switched it so "Verify Identity" (which has a much more involved flow with 2-step verification and all that) to be the "completed" task and moved Vehicle up as something you can now click on. The designs for this flow are labeled as an "Alternative UI" so it's slightly different (but I think friendlier) document chooser than the income document chooser. I kept everything else the same, so there are no routes passed `/loan/{loanId}/vehicle/manual/` but if you want I can add some.